### PR TITLE
commit

### DIFF
--- a/app/redirect_route/page.js
+++ b/app/redirect_route/page.js
@@ -1,0 +1,11 @@
+"use client"
+import React, {useEffect} from 'react'
+
+export default function page() {
+  useEffect(()=>{
+    window.location.href = '/hello'
+  },[])  
+  return (
+    <div>page</div>
+  )
+}

--- a/app/redirect_route/route.ts
+++ b/app/redirect_route/route.ts
@@ -1,3 +1,0 @@
-export async function GET() {
-    return new Response(null, { status: 307, headers: { location: "/hello" } });
-}


### PR DESCRIPTION
Fix the redirect issue #59217. Initially, it redirects to your 'redirect_route,' then it redirects again to your '/hello' route and displays content from your 'hello' route. 

https://github.com/cloudkite/next-redirect-bug/assets/84085024/cfff2426-9bbc-455f-bb94-487f1a7da956

